### PR TITLE
Update 参与genesis.md

### DIFF
--- a/docs_CN/参与genesis.md
+++ b/docs_CN/参与genesis.md
@@ -24,7 +24,7 @@ hashgard add-genesis-account ${your_wallet_name} 100000000gard
 ## 第4步：向 genesis.json 中添加账户信息
 
 ```bash
-hashgard gentx --name=root --amount=100000000gard --ip=${validator_ip}
+hashgard gentx --name=${your_wallet_name} --amount=100000000gard --ip=${validator_ip}
 ```
 
 > 注意：name仅支持ASCII字符。使用Unicode字符将使您的节点无法访问。


### PR DESCRIPTION
hashgard gentx --name的参数是用于签署 gentx 的私钥的名（钱包的名字）不是一个固定的值